### PR TITLE
Switch to a better privileges check

### DIFF
--- a/wwa-menus.php
+++ b/wwa-menus.php
@@ -37,15 +37,23 @@ function wwa_save_user_profile_fields($user_id){
 }
 add_action('personal_options_update', 'wwa_save_user_profile_fields');
 
+function wwa_validate_privileges() {
+    $user = wp_get_current_user();
+    $allowed_roles = array( 'administrator' );
+    if ( array_intersect( $allowed_roles, $user->roles ) ) {
+    return true;
+    }
+    return false;
+}
+
 // Check user can
 function wwa_user_profile_fields_check(){
     if(current_user_can('edit_users')){
         add_action('edit_user_profile', 'wwa_user_profile_fields');
         add_action('edit_user_profile_update', 'wwa_save_user_profile_fields');
     }
-    if(current_user_can('edit_plugins')){
+    if(true === wwa_validate_privileges()){
         add_action('admin_menu', 'wwa_admin_menu');
     }
 }
 add_action('plugins_loaded', 'wwa_user_profile_fields_check');
-?>


### PR DESCRIPTION
The capability edit_plugins was originally intended for when editing the files of a plugin (PHP, JS) though the online file editor. A problem with this is if you have for security reasons added define( ‘DISALLOW_FILE_EDIT’, true ); to your website no one has the edit_plugins rights. As described here: https://wordpress.org/support/topic/improved-way-to-check-for-sufficient-priviliges/