### PR TITLE
Show passkey icon on toggle button when starting in password mode

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -239,8 +239,20 @@ document.addEventListener('DOMContentLoaded', () => {
         button_toggle.id = 'wp-webauthn';
         button_toggle.type = 'button';
         button_toggle.className = 'button button-large';
-        button_toggle.innerHTML = '<span class="dashicons dashicons-ellipsis password-icon"></span>';
-        button_toggle.title = wwa_login_php_vars.i18n_13;
+        if (wwa_login_php_vars.first_choice === 'false') {
+            // Page starts in password mode: toggle button switches TO passkey mode
+            if (wwa_login_php_vars.terminology === 'passkey') {
+                button_toggle.innerHTML = wwa_passkey_btn_svg;
+                button_toggle.style.lineHeight = '0';
+            } else {
+                button_toggle.innerHTML = '<span class="dashicons dashicons-shield-alt"></span>';
+            }
+            button_toggle.title = wwa_login_php_vars.i18n_14;
+        } else {
+            // Page starts in passkey mode: toggle button switches TO password mode
+            button_toggle.innerHTML = '<span class="dashicons dashicons-ellipsis password-icon"></span>';
+            button_toggle.title = wwa_login_php_vars.i18n_13;
+        }
     }
     let submit = document.getElementById('wp-submit');
     if (submit) {

--- a/wwa-functions.php
+++ b/wwa-functions.php
@@ -191,6 +191,7 @@ function wwa_login_js(){
         'email_login' => (wwa_get_option('email_login') === false ? 'false' : wwa_get_option('email_login')),
         'allow_authenticator_type' => (wwa_get_option('allow_authenticator_type') === false ? "none" : wwa_get_option('allow_authenticator_type')),
         'webauthn_only' => ($first_choice === 'webauthn' && !$wwa_not_allowed) ? 'true' : 'false',
+        'first_choice' => ($first_choice === false ? 'true' : $first_choice),
         'password_reset' => ((wwa_get_option('password_reset') === false || wwa_get_option('password_reset') === 'off') ? 'false' : 'true'),
         'separator' => apply_filters('login_link_separator', ' | '),
         'terminology' => (wwa_get_option('terminology') === false ? 'passkey' : wwa_get_option('terminology')),


### PR DESCRIPTION
  When `first_choice` is `false`, the login page starts in password mode
  and the toggle button is meant to switch the user to passkey mode — so
  its icon should be the passkey SVG. It was always initialized with the
  ellipsis dashicon, which only matches a passkey-first initial state.

  Expose `first_choice` through `wwa_login_php_vars` and use it in
  `login.js` to pick the correct initial icon and title:
  - `first_choice === 'false'` → passkey SVG (or `shield-alt` if terminology is not `passkey`), title `i18n_14`
  - otherwise → ellipsis dashicon, title `i18n_13`